### PR TITLE
Always render wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-plugin-block-calendar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A plugin to render a calendar in block, so you can put it onto right side bar.",
   "main": "index.html",
   "scripts": {

--- a/src/common/funcs.ts
+++ b/src/common/funcs.ts
@@ -305,6 +305,7 @@ export function provideStyle(opts: any = {}) {
     style: `
     .logseq-block-calendar {
       width: ${logseq.settings?.tableWidth || "100%"}
+      user-select: none;
     }
     .logseq-block-calendar tr:nth-child(even) {
       background-color: transparent;
@@ -323,26 +324,20 @@ export function provideStyle(opts: any = {}) {
       padding: 0;
       text-align: center;
     }
-
     .logseq-block-calendar .calendar-head {
       font-weight: bold;
       color: #999;
     }
-
     .logseq-block-calendar {
       margin: 0;
     }
-
     .logseq-block-calendar a {
       color: #000;
     }
-
-
     .logseq-block-calendar .calendar-day-today {
       font-weight: bold;
       color: blue;
     }
-
     .logseq-block-calendar .calendar-nav {
       text-align: right;
       font-size: 14px;
@@ -360,6 +355,10 @@ export function provideStyle(opts: any = {}) {
       margin: auto;
       margin-top: -2px;
       border-radius: 100%;
+    }
+    #right-sidebar-container #calendar-placeholder {
+      padding: 6px 16px 6px 12px;
+      border-top: 1px solid var(--ls-border-color);
     }
     `,
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ const defineSettings: SettingSchemaDesc[] = [
     title: "",
     description:
       "Always render calendar always in custom HTML element (provide CSS selector: ID or class)",
-    default: "#banner-widget-calendar",
+    default: ".sidebar-item-list",
   },
 ];
 
@@ -104,22 +104,34 @@ const main = async () => {
     }
   });
 
-  if (logseq.settings?.alwaysRenderIn) {
-    const now = new Date();
-    const calendar = await setCal(
-      now.getFullYear(),
-      now.getMonth(),
-      logseq.settings.alwaysRenderIn.substring(1),
-      logseq.settings?.defaultLanguage,
-      []
-    );
-    logseq.provideUI({
-      key: "calendar-widget",
-      path: logseq.settings.alwaysRenderIn,
-      reset: true,
-      template: calendar,
-    });
+  const renderAlwaysIn = async (containerSeelector: string) => {
+    if (containerSeelector) {
+      const calendarPlaceholderId = "calendar-placeholder";
+      const container = top?.document.querySelector(containerSeelector) as HTMLElement;
+      if (container) {
+        const calendarPlaceholder = top!.document.createElement("div");
+        calendarPlaceholder.id = calendarPlaceholderId;
+        container.insertAdjacentElement("afterbegin", calendarPlaceholder);
+      }
+      const now = new Date();
+      const calendar = await setCal(
+        now.getFullYear(),
+        now.getMonth(),
+        calendarPlaceholderId,
+        logseq.settings?.defaultLanguage,
+        []
+      );
+      logseq.provideUI({
+        key: "calendar-widget",
+        path: `#${calendarPlaceholderId}`,
+        reset: true,
+        template: calendar,
+      });
+    }
   }
+  setTimeout(() => {
+    renderAlwaysIn(logseq.settings?.alwaysRenderIn)
+  }, 1000)
 
   provideStyle();
 


### PR DESCRIPTION
Updated previous PR.
Added wrapper to render as 1st child of container, not last (`logseq.provideUI` doing `append`).

Container selector updated to `.sidebar-item-list` (@vipzhicheng, edit your local Logseq settings, old value can be there) - so it's rendered in sidebar 😎
![image](https://user-images.githubusercontent.com/137919/179547683-57e2fb19-12f0-4849-ab49-617eb51c04a6.png)


About "Banner plugin" integration - i will provide a placeholder so users could set a selector in calendar plugin options to use it.