### PR TITLE
Widget rendering refactor + fix lang bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+*.sublime-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 - fix: language param in macro rendering — `en` & `English` are now both valid
 - fix: calendar widget updated when journal blocks change
 - fix: calendar widget updating when widget is out of right sidebar
-- fix: diabling journals does not imply block calendar disabling
+- fix: disabling journals does not imply block calendar disabling
 
 - refactor: generalize providing calendar UI code
-- refactor: rewrited calandar widget rendering
+- refactor: rewritten calendar widget rendering
 
 ## v0.1.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.2.0
+
+- fix: language param in macro rendering — `en` & `English` are now both valid
+- fix: calendar widget updated when journal blocks change
+- fix: calendar widget updating when widget is out of right sidebar
+- fix: diabling journals does not imply block calendar disabling
+
+- refactor: generalize providing calendar UI code
+- refactor: rewrited calandar widget rendering
+
 ## v0.1.15
 
 - fix: over fixed console error, change it back
@@ -22,7 +32,7 @@
 
 ## v0.1.10
 
-- fix: wrong calentdar on 2023-01
+- fix: wrong calendar on 2023-01
 
 ## v0.1.9
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ A plugin to render a calendar in block, so you can put it onto right side bar.
 
 ## Usage
 
-- Slash command `/Insert Block Calendar`  to insert a calendar
-- `{{renderer block-calendar, [2022], [7], [en], [nohead|nonav]}}`
-  - `[2022]`, `[7]`, `[en]` is optional.
-  - Only support `zh-CN` and `en` language, PR is welcome.
+- Slash command `/Insert Block Calendar` to insert a calendar for current month
+- `{{renderer block-calendar, 2022, 7}}` to insert a calendar for specified month and year
+- `{{renderer block-calendar, 2022, 7, en}}` to insert a calendar for specified language
+  - Supported languages: `en`, `fr`, `de`,  `zh-CN`, `zh-Hant`, `af`,  `es`,  `nb-NO`,  `pt-BR`,  `pt-PT`,  `ru`,  `ja`,  `it`,  `tr`,  `ko`
+- `{{renderer block-calendar, 2022, 7, en, nohead|nonav}}`
   - `nohead` means do not have table head, so no month and year and month switcher.
   - `nonav` means still have month and year, but no month switcher.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-plugin-block-calendar",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "A plugin to render a calendar in block, so you can put it onto right side bar.",
   "main": "index.html",
   "scripts": {

--- a/src/common/funcs.ts
+++ b/src/common/funcs.ts
@@ -26,6 +26,10 @@ export const languageMapping: {
   한국어: "ko",
 };
 
+export function print(msg) {
+  console.info(`#${logseq.baseInfo.id}: ${msg}`);
+}
+
 function leapYear(year: number) {
   if (year % 4 == 0)
     // basic rule
@@ -54,7 +58,7 @@ function getDays(month: number, year: number) {
   return ar[month];
 }
 
-async function getMonthName(month: number, lang: any) {
+function getMonthName(month: number, lang: any) {
   // create array to hold name of each month
   const ar = new Array(12);
   ar[0] = lang.January;
@@ -82,10 +86,9 @@ export async function setCal(
   options: string[] = []
 ) {
   clearCachedDays();
-  language = language || logseq.settings?.defaultLanguage;
-  const lang = await getLang(language);
+  const lang = getLang(language);
   const now = new Date();
-  const monthName = await getMonthName(month0, lang);
+  const monthName = getMonthName(month0, lang);
   const date = now.getDate();
   // create instance of first day of month, and extract the day on which it occurs
   const firstDayInstance = new Date(year4, month0, 1);
@@ -109,16 +112,19 @@ export async function setCal(
   );
 }
 
-export const getLang = async (language: string) => {
-  type Lang = keyof typeof langs;
-  const lang: Lang = (
-    Object.keys(langs).includes(languageMapping[language])
-      ? languageMapping[language]
-      : "en"
-  ) as Lang;
+export function getLang(language: string) {
+  let lang = language;
+
+  if (Object.keys(langs).includes(languageMapping[lang])) {
+    lang = languageMapping[lang];
+  }
+
+  if (!Object.keys(langs).includes(lang)) {
+    lang = languageMapping[logseq.settings?.defaultLanguage];
+  }
 
   return langs[lang];
-};
+}
 
 let journalDays: number[] = [];
 async function getJournalDays(year: number, month: number) {
@@ -209,10 +215,6 @@ export function clearCachedDays() {
   undoneTaskDays = [];
   doneTaskDays = [];
 }
-
-logseq.App.onCurrentGraphChanged(() => {
-  clearCachedDays();
-});
 
 export async function drawCal(
   firstDay: number,
@@ -627,7 +629,7 @@ export function provideStyle(opts: any = {}) {
       margin: auto;
       border-radius: 100%;
     }
-    #right-sidebar-container #calendar-placeholder {
+    #right-sidebar-container #block-calendar-widget_placeholder {
       padding: 6px 16px 6px 12px;
     }
     `,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import "@logseq/libs";
 import { SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin";
-import { setCal, provideStyle, languageMapping, getLang } from "./common/funcs";
+import { setCal, provideStyle, languageMapping, getLang, clearCachedDays, print } from "./common/funcs";
 import langs from "./lang";
+import { logseq as logseqPackageSection } from "../package.json";
+
 
 const defineSettings: SettingSchemaDesc[] = [
   {
@@ -84,6 +86,43 @@ logseq.onSettingsChanged(() => {
   provideStyle();
 });
 
+logseq.App.onGraphAfterIndexed(() => {
+  clearCachedDays();
+});
+logseq.App.onCurrentGraphChanged(() => {
+  clearCachedDays();
+});
+
+
+const calendarKeyPrefix = "block-calendar-";
+
+const calendarWidgetSlot = "widget";
+const calendarWidgetKey = calendarKeyPrefix + calendarWidgetSlot;
+const calendarWidgetPlaceholder = `#${calendarWidgetKey}_placeholder`;
+
+
+function provideCalendarUI(calendar: string, slot: string) {
+  if (!slot) {
+    throw new Error("Attemp to render without slot");
+  }
+  
+  const params = {
+    reset: true,
+    template: calendar,
+  };
+
+  if (slot === calendarWidgetSlot) {
+    params.key = calendarWidgetKey;
+    params.path = calendarWidgetPlaceholder;
+  } else {
+    params.key = calendarKeyPrefix + slot;
+    params.slot = slot;
+  }
+
+  logseq.provideUI(params);
+}
+
+
 const main = async () => {
   logseq.Editor.registerSlashCommand("Insert Block Calendar", async () => {
     await logseq.Editor.insertAtEditingCursor(`{{renderer block-calendar}} `);
@@ -101,22 +140,13 @@ const main = async () => {
 
     async loadCalendar(e: any) {
       const { year, month, slot, language, options } = e.dataset;
+
       if (year && month) {
         const year4 = Number(year);
         const month0 = Number(month) - 1;
-        const calendar = await setCal(
-          year4,
-          month0,
-          slot,
-          language,
-          options.split(" ")
-        );
-        logseq.provideUI({
-          key: "block-calendar-" + slot,
-          slot,
-          reset: true,
-          template: calendar,
-        });
+
+        const calendar = await setCal(year4, month0, slot, language, options.split(" "));
+        provideCalendarUI(calendar, slot);
       }
     },
 
@@ -124,7 +154,7 @@ const main = async () => {
       let { year, slot, language, options } = e.dataset;
       if (year) {
         language = language || logseq.settings?.defaultLanguage;
-        const lang = await getLang(language);
+        const lang = getLang(language);
         const now = new Date();
         const year4 = year ? Number(year) : now.getFullYear();
         let monthView = "";
@@ -155,7 +185,7 @@ const main = async () => {
 
         logseq.provideUI({
           key: "block-calendar-yearly-" + slot,
-          slot,
+          slot: slot,
           reset: true,
           template: template,
         });
@@ -166,22 +196,16 @@ const main = async () => {
   logseq.App.onMacroRendererSlotted(async ({ slot, payload }) => {
     let [type] = payload.arguments;
     if (type === "block-calendar") {
-      let [_, year, month, lang, ...options] = payload.arguments;
+      let [_, year, month, language, ...options] = payload.arguments;
       const now = new Date();
       const year4 = year ? Number(year) : now.getFullYear();
       const month0 = month ? Number(month) - 1 : now.getMonth();
 
-      const calendar = await setCal(year4, month0, slot, lang, options);
-      logseq.provideUI({
-        key: "block-calendar-" + slot,
-        slot,
-        reset: true,
-        template: calendar,
-      });
+      const calendar = await setCal(year4, month0, slot, language, options);
+      provideCalendarUI(calendar, slot);
     } else if (type === "block-calendar-yearly") {
       let [_, year, language] = payload.arguments;
-      language = language || logseq.settings?.defaultLanguage;
-      const lang = await getLang(language);
+      const lang = getLang(language);
       const now = new Date();
       const year4 = year ? Number(year) : now.getFullYear();
       let monthView = "";
@@ -212,82 +236,94 @@ const main = async () => {
 
       logseq.provideUI({
         key: "block-calendar-yearly-" + slot,
-        slot,
+        slot: slot,
         reset: true,
         template: template,
       });
     }
   });
 
-  const renderAlwaysIn = async (containerSelector: string) => {
-    const config = await logseq.App.getUserConfigs();
-    const calendarPlaceholderId = "calendar-placeholder";
+  const renderAlwaysIn = async (containerSelector: string, recreate: boolean = false) => {
+    let widgetPlaceholder = top?.document.querySelector(`${calendarWidgetPlaceholder}`) as HTMLElement;
 
-    if (containerSelector && config.enabledJournals) {
-      const container = top?.document.querySelector(
-        containerSelector
-      ) as HTMLElement;
-      const placeholderExist = top?.document.querySelector(
-        `#${calendarPlaceholderId}`
-      ) as HTMLElement;
-      if (placeholderExist) {
-        placeholderExist.style.display = "block";
+    const remove = (widgetPlaceholder) => {
+      if (!widgetPlaceholder) {
+        return;
       }
-      if (container && !placeholderExist) {
-        const calendarPlaceholder = top!.document.createElement("div");
-        calendarPlaceholder.id = calendarPlaceholderId;
-        calendarPlaceholder.style.display = "block";
-        container.insertAdjacentElement("afterbegin", calendarPlaceholder);
-      }
+      
+      print("Remove widget placeholder");
 
-      const now = new Date();
-      const calendar = await setCal(
-        now.getFullYear(),
-        now.getMonth(),
-        calendarPlaceholderId,
-        logseq.settings?.defaultLanguage,
-        []
-      );
-      logseq.provideUI({
-        key: "calendar-widget",
-        path: `#${calendarPlaceholderId}`,
-        reset: true,
-        template: calendar,
-      });
-    } else {
-      const placeholderExist = top?.document.querySelector(
-        `#${calendarPlaceholderId}`
-      ) as HTMLElement;
-      if (placeholderExist) {
-        placeholderExist.style.display = "none";
-      }
-      if (placeholderExist) {
-        logseq.provideUI({
-          key: "calendar-widget",
-          path: `#${calendarPlaceholderId}`,
-          reset: true,
-          template: "",
-        });
-      }
+      widgetPlaceholder.style.display = "none";
+      widgetPlaceholder.remove();
+      widgetPlaceholder = null;
+    };
+
+    if (!containerSelector) {
+      remove(widgetPlaceholder);
+      return;
     }
+    
+    const container = top?.document.querySelector(containerSelector) as HTMLElement;
+    if (!container) {
+      remove(widgetPlaceholder);
+      return;
+    }
+
+    if (!widgetPlaceholder || recreate) {
+      remove(widgetPlaceholder);
+      print("Create new widget placeholder");
+
+      widgetPlaceholder = top!.document.createElement("div");
+      widgetPlaceholder.id = calendarWidgetPlaceholder.slice(1);
+      container.insertAdjacentElement("afterbegin", widgetPlaceholder);
+    }
+    widgetPlaceholder.style.display = "block";
+
+    const now = new Date();
+    const calendar = await setCal(
+      now.getFullYear(),
+      now.getMonth(),
+      calendarWidgetSlot,
+      logseq.settings?.defaultLanguage,
+      []
+    );
+    provideCalendarUI(calendar, calendarWidgetSlot);
   };
 
   setTimeout(async () => {
     await renderAlwaysIn(logseq.settings?.alwaysRenderIn);
   }, 1000);
+
+  logseq.App.onGraphAfterIndexed(() => {
+    setTimeout(async () => {
+      await renderAlwaysIn(logseq.settings?.alwaysRenderIn);
+    }, 1000);
+  });
+
   logseq.App.onCurrentGraphChanged(() => {
     setTimeout(async () => {
       await renderAlwaysIn(logseq.settings?.alwaysRenderIn);
     }, 1000);
   });
+
   logseq.App.onSidebarVisibleChanged(async (e) => {
     if (e.visible) {
       await renderAlwaysIn(logseq.settings?.alwaysRenderIn);
     }
   });
+
   logseq.onSettingsChanged(async (newSettings: any, oldSettings: any) => {
     if (newSettings.alwaysRenderIn !== oldSettings.alwaysRenderIn) {
-      await renderAlwaysIn(newSettings.alwaysRenderIn);
+      await renderAlwaysIn(newSettings.alwaysRenderIn, true);
+    }
+  });
+
+  logseq.DB.onChanged(async ({blocks, txData, txMeta}) => {
+    for (const block of blocks) {
+      if (block.journalDay) {
+        await renderAlwaysIn(logseq.settings?.alwaysRenderIn);
+        return;
+      }
     }
   });
 


### PR DESCRIPTION
* fix: language param doesn't working
* fix: language param in macro rendering — `en` & `English` are now both valid
* fix: calendar widget updated when journal blocks change
* fix: calendar widget updating when widget is out of right sidebar
* fix: disabling journals does not imply block calendar disabling

- refactor: generalize providing calendar UI code
- refactor: rewritten calendar widget rendering

* version inc: 0.2.0

### Rendering widget bug:
https://user-images.githubusercontent.com/1984175/215632341-51cfc053-ad0b-46ea-98eb-a5f5001c819f.mp4

### Updating widget bug:
https://user-images.githubusercontent.com/1984175/215632391-b61591b4-4fff-49b8-960c-2b818abc3bac.mp4
