### PR TITLE
fix: january bug

### DIFF
--- a/src/common/funcs.ts
+++ b/src/common/funcs.ts
@@ -39,9 +39,9 @@ function isInteger(x: number | string) {
 }
 
 export function parseYearMonth(year: any, month: any, now: Date = new Date()) {
-  const year4 = isInteger(year) ? Number(year) : now?.getFullYear() || null;
-  const month0 = isInteger(month) ? Number(month) - 1 : now?.getMonth() || null;
-  return [year4, month0];
+  const year4 = isInteger(year) ? Number(year) : now?.getFullYear();
+  const month0 = isInteger(month) ? Number(month) - 1 : now?.getMonth();
+  return [year4 ?? null, month0 ?? null];
 }
 
 export function parseOptions(


### PR DESCRIPTION
Fixing these issue #36 

Problem in `parseYearMonth` function. It is became visible in January:
```javascript
> (isInteger(month) ? Number(month) - 1 : now?.getMonth()) || null
null
> (isInteger(month) ? Number(month) - 1 : now?.getMonth()) ?? null
0
```